### PR TITLE
Tweak scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,10 +27,8 @@
     "setup": "corepack enable pnpm",
     "build": "tsup src/index.ts --format esm,cjs --dts",
     "test": "vitest",
-    "lint": "biome check .",
-    "format": "pnpm format:biome:format && pnpm format:biome:check",
-    "format:biome:format": "biome format --write .",
-    "format:biome:check": "biome check --apply ."
+    "lint": "biome lint .",
+    "format": "biome check --apply ."
   },
   "dependencies": {
     "@urql/core": ">=4.0.0",


### PR DESCRIPTION
The `biome check` command applies both `biome format` and `biome lint`, so the `format` script is enough for `biome check --apply`.

https://biomejs.dev/guides/getting-started/#usage