### PR TITLE
use biome ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: ./.github/composite-actions/setup-node
-      - run: pnpm lint
+      - name: Setup Biome
+        uses: biomejs/setup-biome@v2
+        with:
+          version: latest
+      - name: Run Biome
+        run: biome ci .
   test:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Is there any reason why you are not using Biome's first party [GitHub Action](https://github.com/marketplace/actions/setup-biome)?

document: https://biomejs.dev/recipes/continuous-integration/