### PR TITLE
Transfer this repo from `route06` to `route06inc`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # urql-exhaustive-additional-typenames-exchange
 
 [![npm version](https://badge.fury.io/js/urql-exhaustive-additional-typenames-exchange.svg)](https://badge.fury.io/js/urql-exhaustive-additional-typenames-exchange)
-[![ci](https://github.com/route06/urql-exhaustive-additional-typenames-exchange/actions/workflows/ci.yml/badge.svg)](https://github.com/route06/urql-exhaustive-additional-typenames-exchange/actions/workflows/ci.yml)
+[![ci](https://github.com/route06inc/urql-exhaustive-additional-typenames-exchange/actions/workflows/ci.yml/badge.svg)](https://github.com/route06inc/urql-exhaustive-additional-typenames-exchange/actions/workflows/ci.yml)
 
 `urql-exhaustive-additional-typenames-exchange` add all list fields in an operation to additionalTypenames.  
 This is useful if your project is more about avoiding the risk of bugs from cache operations than cache efficiency.

--- a/package.json
+++ b/package.json
@@ -12,14 +12,14 @@
   "main": "./dist/index.js",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/route06/urql-exhaustive-additional-typenames-exchange.git"
+    "url": "git+https://github.com/route06inc/urql-exhaustive-additional-typenames-exchange.git"
   },
   "keywords": ["urql", "exchange", "graphql", "exchanges"],
   "files": ["LICENSE", "CHANGELOG.md", "README.md", "dist/"],
   "bugs": {
-    "url": "https://github.com/route06/urql-exhaustive-additional-typenames-exchange/issues"
+    "url": "https://github.com/route06inc/urql-exhaustive-additional-typenames-exchange/issues"
   },
-  "homepage": "https://github.com/route06/urql-exhaustive-additional-typenames-exchange",
+  "homepage": "https://github.com/route06inc/urql-exhaustive-additional-typenames-exchange",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
As I told you, I have transferred this repository from `route06` org to `route06inc`. Therefore, I have replaced some text.

Once you merge this PR, please release a new version.
