### PR TITLE
Pin third-party GitHub Actions versions with Full Changeset Hash

### DIFF
--- a/.github/composite-actions/setup-node/action.yml
+++ b/.github/composite-actions/setup-node/action.yml
@@ -3,7 +3,7 @@ name: Setup Node
 runs:
   using: "composite"
   steps:
-    - uses: pnpm/action-setup@v3
+    - uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3.0.0
       with:
         version: 8
     - uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup Biome
-        uses: biomejs/setup-biome@v2
+        uses: biomejs/setup-biome@c016c38f26f2c4a6eb3662679143614a254263fd # v2.3.0
         with:
           version: latest
       - name: Run Biome


### PR DESCRIPTION
## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->
To mitigate the risk of third-party GitHub Actions being compromised with malware, I are now pinning their versions using Full Changeset Hashes.

Previously, some GitHub Actions were pinned to major versions like v2, allowing for loose version upgrades. With this change, such automatic upgrades will no longer occur.

## What would you like reviewers to focus on?
<!-- What specific aspects are you requesting review for? -->
* We will not pin the versions of official GitHub Actions using Full Changeset Hashes
* This PR does not upgrade any GitHub Actions
    * Using https://github.com/suzuki-shunsuke/pinact
* Since this repository is updated infrequently, we will not introduce Dependabot version updates to update GitHub Actions like this:
    * https://github.com/liam-hq/liam/pull/910

## Additional Notes

> * Using https://github.com/suzuki-shunsuke/pinact

1. Create .pinact.yaml

    ```console
    pinact init
    ```

2. Edit .pinact.yaml

    ```diff
    --- .pinact.yaml.bak	2025-03-17 16:29:26
    +++ .pinact.yaml	2025-03-17 16:31:10
    @@ -5,5 +5,6 @@
       - pattern: "^(.*/)?action\\.ya?ml$"
     
     ignore_actions:
    -# - name: actions/checkout
    -# - name: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml
    +  - name: actions/checkout
    +  - name: actions/setup-node
    +  - name: route06/actions/.github/workflows/dependency_review.yml
    ```

3. Update .github/workflows/*.yml

    ```console
    pinact run
    ```

4. Verify version annotations

    ```console
    pinact run --verify
    ```
