### PR TITLE
pin GitHub Actions to full-length commit SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Biome
         uses: biomejs/setup-biome@c016c38f26f2c4a6eb3662679143614a254263fd # v2.3.0
         with:
@@ -20,6 +20,6 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: ./.github/composite-actions/setup-node
       - run: pnpm test

--- a/.github/workflows/dependency_review.yml
+++ b/.github/workflows/dependency_review.yml
@@ -8,4 +8,4 @@ permissions:
 
 jobs:
   dependency_review:
-    uses: route06/actions/.github/workflows/dependency_review.yml@v2
+    uses: route06/actions/.github/workflows/dependency_review.yml@3bcea5bf834ff2e0e6c912c1167fcc1fe05e49c2 # v2


### PR DESCRIPTION
## Summary
- Pin GitHub Actions references to full-length commit SHAs
- Preparation for enabling Enforce SHA pinning policy as a supply chain attack countermeasure

🤖 Generated with [Claude Code](https://claude.com/claude-code)